### PR TITLE
feat: enhance month configuration workflow

### DIFF
--- a/src/hooks/useMonthConfig.ts
+++ b/src/hooks/useMonthConfig.ts
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { getMonthConfig, updateMonthConfig } from "@/lib/api"
+import type { MonthConfig, WeekendPolicy } from "@/types"
+
+interface MonthConfigState {
+  loading: boolean
+  saving: boolean
+  error: string | null
+  data: MonthConfig | null
+  isMissing: boolean
+}
+
+export interface SaveMonthConfigPayload {
+  weekend_policy: WeekendPolicy
+  extra_offdays: string[]
+  extra_workdays: string[]
+  working_days_override: number | null
+  auto_working_days: number | null
+}
+
+function isValidSelection(year: number | null | undefined, month: number | null | undefined): boolean {
+  return typeof year === "number" && Number.isFinite(year) && typeof month === "number" && Number.isFinite(month)
+}
+
+export function useMonthConfig(year: number | null | undefined, month: number | null | undefined) {
+  const [state, setState] = useState<MonthConfigState>({
+    loading: false,
+    saving: false,
+    error: null,
+    data: null,
+    isMissing: false,
+  })
+  const selection = useMemo(() =>
+    isValidSelection(year, month) ? `${year}-${month}` : null,
+  [month, year])
+  const activeRequest = useRef<AbortController | null>(null)
+
+  const load = useCallback(async () => {
+    if (!selection) {
+      setState((previous) => ({ ...previous, data: null, isMissing: false }))
+      return null
+    }
+
+    activeRequest.current?.abort()
+    const controller = new AbortController()
+    activeRequest.current = controller
+
+    setState((previous) => ({ ...previous, loading: true, error: null }))
+
+    try {
+      const [selectedYear, selectedMonth] = selection.split("-").map((value) => Number(value))
+      const data = await getMonthConfig(selectedYear, selectedMonth)
+      if (controller.signal.aborted) {
+        return null
+      }
+
+      setState((previous) => ({
+        ...previous,
+        loading: false,
+        data,
+        isMissing: data === null,
+        error: null,
+      }))
+      return data
+    } catch (error: unknown) {
+      if (controller.signal.aborted) {
+        return null
+      }
+
+      const message = error instanceof Error ? error.message : "Không thể tải cấu hình tháng"
+      setState((previous) => ({
+        ...previous,
+        loading: false,
+        error: message,
+        data: null,
+        isMissing: false,
+      }))
+      throw error
+    }
+  }, [selection])
+
+  const save = useCallback(
+    async (payload: SaveMonthConfigPayload) => {
+      if (!selection) {
+        throw new Error("Thiếu thông tin tháng cần lưu")
+      }
+
+      const [selectedYear, selectedMonth] = selection.split("-").map((value) => Number(value))
+      const autoWorkingDays =
+        payload.auto_working_days !== undefined
+          ? payload.auto_working_days
+          : state.data?.auto_working_days ?? null
+
+      const optimistic: MonthConfig = {
+        year: selectedYear,
+        month: selectedMonth,
+        weekend_policy: payload.weekend_policy,
+        extra_offdays: [...payload.extra_offdays].sort(),
+        extra_workdays: [...payload.extra_workdays].sort(),
+        working_days_override: payload.working_days_override,
+        auto_working_days: autoWorkingDays ?? 0,
+      }
+
+      const previous = state.data
+
+      setState((current) => ({
+        ...current,
+        data: optimistic,
+        saving: true,
+        isMissing: false,
+      }))
+
+      try {
+        const saved = await updateMonthConfig({
+          year: optimistic.year,
+          month: optimistic.month,
+          weekend_policy: optimistic.weekend_policy,
+          extra_offdays: optimistic.extra_offdays,
+          extra_workdays: optimistic.extra_workdays,
+          working_days_override: optimistic.working_days_override,
+        })
+
+        setState((current) => ({
+          ...current,
+          data: saved ?? optimistic,
+          saving: false,
+          error: null,
+          isMissing: false,
+        }))
+
+        return saved ?? optimistic
+      } catch (error) {
+        setState((current) => ({
+          ...current,
+          data: previous ?? null,
+          saving: false,
+          isMissing: previous === null,
+          error: error instanceof Error ? error.message : "Không thể lưu cấu hình tháng",
+        }))
+
+        throw error
+      }
+    },
+    [selection, state.data],
+  )
+
+  useEffect(() => {
+    void load()
+    return () => {
+      activeRequest.current?.abort()
+    }
+  }, [load])
+
+  return {
+    ...state,
+    refetch: load,
+    save,
+  }
+}

--- a/src/hooks/useShiftDefaults.ts
+++ b/src/hooks/useShiftDefaults.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { getShiftDefaultConfig, updateShiftDefaultConfig } from "@/lib/api"
+import type { ShiftDefaultConfig } from "@/types"
+
+interface ShiftDefaultsState {
+  loading: boolean
+  saving: boolean
+  error: string | null
+  data: ShiftDefaultConfig | null
+}
+
+function isValidSelection(year: number | null | undefined, month: number | null | undefined): boolean {
+  return typeof year === "number" && Number.isFinite(year) && typeof month === "number" && Number.isFinite(month)
+}
+
+export function useShiftDefaults(year: number | null | undefined, month: number | null | undefined) {
+  const [state, setState] = useState<ShiftDefaultsState>({
+    loading: false,
+    saving: false,
+    error: null,
+    data: null,
+  })
+  const selection = useMemo(() => (isValidSelection(year, month) ? `${year}-${month}` : null), [month, year])
+  const activeRequest = useRef<AbortController | null>(null)
+
+  const load = useCallback(async () => {
+    if (!selection) {
+      setState((previous) => ({ ...previous, data: null }))
+      return null
+    }
+
+    activeRequest.current?.abort()
+    const controller = new AbortController()
+    activeRequest.current = controller
+
+    setState((previous) => ({ ...previous, loading: true, error: null }))
+
+    try {
+      const [selectedYear, selectedMonth] = selection.split("-").map((value) => Number(value))
+      const data = await getShiftDefaultConfig(selectedYear, selectedMonth)
+      if (controller.signal.aborted) {
+        return null
+      }
+
+      setState((previous) => ({
+        ...previous,
+        loading: false,
+        data,
+        error: null,
+      }))
+      return data
+    } catch (error: unknown) {
+      if (controller.signal.aborted) {
+        return null
+      }
+
+      const message = error instanceof Error ? error.message : "Không thể tải mặc định ca"
+      setState((previous) => ({
+        ...previous,
+        loading: false,
+        error: message,
+        data: null,
+      }))
+      throw error
+    }
+  }, [selection])
+
+  const save = useCallback(
+    async (defaults: Record<string, number>) => {
+      if (!selection) {
+        throw new Error("Thiếu thông tin tháng cần lưu mặc định ca")
+      }
+
+      const [selectedYear, selectedMonth] = selection.split("-").map((value) => Number(value))
+      const optimistic: ShiftDefaultConfig = {
+        year: selectedYear,
+        month: selectedMonth,
+        defaults: { ...defaults },
+      }
+      const previous = state.data
+
+      setState((current) => ({
+        ...current,
+        data: optimistic,
+        saving: true,
+      }))
+
+      try {
+        const saved = await updateShiftDefaultConfig({
+          year: optimistic.year,
+          month: optimistic.month,
+          defaults: optimistic.defaults,
+        })
+
+        setState((current) => ({
+          ...current,
+          data: saved ?? optimistic,
+          saving: false,
+          error: null,
+        }))
+
+        return saved ?? optimistic
+      } catch (error) {
+        setState((current) => ({
+          ...current,
+          data: previous ?? null,
+          saving: false,
+          error: error instanceof Error ? error.message : "Không thể lưu mặc định ca",
+        }))
+
+        throw error
+      }
+    },
+    [selection, state.data],
+  )
+
+  useEffect(() => {
+    void load()
+    return () => {
+      activeRequest.current?.abort()
+    }
+  }, [load])
+
+  return {
+    ...state,
+    refetch: load,
+    save,
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -253,10 +253,13 @@ export async function importHolidaysFromNager(year: number): Promise<{ imported:
 export async function getMonthConfig(
   year: number,
   month: number,
-): Promise<MonthConfig> {
-  return parseJsonResponse<MonthConfig>(
-    await fetch(`/api/month-config?year=${year}&month=${month}`),
-  )
+): Promise<MonthConfig | null> {
+  const response = await fetch(`/api/month-config?year=${year}&month=${month}`)
+  if (response.status === 404) {
+    return null
+  }
+
+  return parseJsonResponse<MonthConfig>(response)
 }
 
 export async function updateMonthConfig(
@@ -274,10 +277,13 @@ export async function updateMonthConfig(
 export async function getShiftDefaultConfig(
   year: number,
   month: number,
-): Promise<ShiftDefaultConfig> {
-  return parseJsonResponse<ShiftDefaultConfig>(
-    await fetch(`/api/shift-defaults?year=${year}&month=${month}`),
-  )
+): Promise<ShiftDefaultConfig | null> {
+  const response = await fetch(`/api/shift-defaults?year=${year}&month=${month}`)
+  if (response.status === 404) {
+    return null
+  }
+
+  return parseJsonResponse<ShiftDefaultConfig>(response)
 }
 
 export async function updateShiftDefaultConfig(

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -12,6 +12,7 @@ import {
 
 import { PageHeader } from "@/components/PageHeader"
 import { GlassButton, GlassCard } from "@/components/ui/glass"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import {
   Tabs,
   TabsContent,
@@ -52,21 +53,14 @@ import {
 import {
   createHolidayEntry,
   deleteHolidayEntry,
-  getMonthConfig,
-  getShiftDefaultConfig,
   importHolidaysFromNager,
   listHolidaysByYear,
-  updateMonthConfig,
-  updateShiftDefaultConfig,
   generateSchedule,
 } from "@/lib/api"
-import type {
-  Holiday,
-  MonthConfig,
-  ShiftDefaultConfig,
-  WeekendPolicy,
-} from "@/types"
+import type { Holiday, WeekendPolicy } from "@/types"
 import { cn } from "@/lib/utils"
+import { useMonthConfig } from "@/hooks/useMonthConfig"
+import { useShiftDefaults } from "@/hooks/useShiftDefaults"
 
 const BASE_WEEKEND_POLICIES: Array<{ value: WeekendPolicy; label: string }> = [
   { value: "sat_sun", label: "Th\u1ee9 7 & Ch\u1ee7 nh\u1eadt" },
@@ -144,6 +138,7 @@ function formatDisplayDate(input: string): string {
   })
 }
 
+
 function HolidaysTab() {
   const { toast } = useToast()
   const currentYear = React.useMemo(() => new Date().getFullYear(), [])
@@ -154,6 +149,7 @@ function HolidaysTab() {
   const [adding, setAdding] = React.useState(false)
   const [newDate, setNewDate] = React.useState<Date | undefined>()
   const [newName, setNewName] = React.useState("")
+  const [lastImportDelta, setLastImportDelta] = React.useState<number | null>(null)
 
   const sortedHolidays = React.useMemo(
     () =>
@@ -174,14 +170,16 @@ function HolidaysTab() {
       try {
         const result = await listHolidaysByYear(targetYear)
         setHolidays(result)
+        return result
       } catch (error: unknown) {
         const message =
-          error instanceof Error ? error.message : "Kh\u00f4ng th\u1ec3 t\u1ea3i danh s\u00e1ch ng\u00e0y ngh\u1ec9"
+          error instanceof Error ? error.message : "Không thể tải danh sách ngày nghỉ"
         toast({
           variant: "destructive",
-          title: "L\u1ed7i t\u1ea3i d\u1eef li\u1ec7u",
+          title: "Lỗi tải dữ liệu",
           description: message,
         })
+        return undefined
       } finally {
         setLoading(false)
       }
@@ -190,39 +188,44 @@ function HolidaysTab() {
   )
 
   React.useEffect(() => {
+    setLastImportDelta(null)
     void load(year)
   }, [load, year])
 
   const handleImport = React.useCallback(async () => {
     setImporting(true)
     try {
+      const previousCount = holidays.length
       const { imported } = await importHolidaysFromNager(year)
       toast({
-        title: "\u0110\u00e3 \u0111\u1ed3ng b\u1ed9 ng\u00e0y ngh\u1ec9",
+        title: "Đã đồng bộ ngày nghỉ",
         description: imported
-          ? `\u0110\u00e3 th\u00eam ${imported} ng\u00e0y ngh\u1ec9 t\u1eeb Nager.`
-          : "Kh\u00f4ng c\u00f3 ng\u00e0y ngh\u1ec9 m\u1edbi.",
+          ? `Đã thêm ${imported} ngày nghỉ từ Nager.`
+          : "Không có ngày nghỉ mới.",
       })
-      await load(year)
+      const refreshed = await load(year)
+      const nextCount = refreshed ? refreshed.length : previousCount
+      const delta = Math.max(0, nextCount - previousCount)
+      setLastImportDelta(delta > 0 ? delta : null)
     } catch (error: unknown) {
       const message =
-        error instanceof Error ? error.message : "Kh\u00f4ng th\u1ec3 import ng\u00e0y ngh\u1ec9"
+        error instanceof Error ? error.message : "Không thể import ngày nghỉ"
       toast({
         variant: "destructive",
-        title: "Import th\u1ea5t b\u1ea1i",
+        title: "Import thất bại",
         description: message,
       })
     } finally {
       setImporting(false)
     }
-  }, [load, toast, year])
+  }, [holidays.length, load, toast, year])
 
   const handleAdd = React.useCallback(async () => {
     if (!newDate) {
       toast({
         variant: "destructive",
-        title: "Thi\u1ebfu ng\u00e0y ngh\u1ec9",
-        description: "Vui l\u00f2ng ch\u1ecdn ng\u00e0y tr\u01b0\u1edbc khi th\u00eam.",
+        title: "Thiếu ngày nghỉ",
+        description: "Vui lòng chọn ngày trước khi thêm.",
       })
       return
     }
@@ -231,8 +234,8 @@ function HolidaysTab() {
     if (holidays.some((holiday) => holiday.day === isoDate)) {
       toast({
         variant: "destructive",
-        title: "Ng\u00e0y \u0111\u00e3 t\u1ed3n t\u1ea1i",
-        description: "Ng\u00e0y ngh\u1ec9 n\u00e0y \u0111\u00e3 c\u00f3 trong danh s\u00e1ch.",
+        title: "Ngày đã tồn tại",
+        description: "Ngày nghỉ này đã có trong danh sách.",
       })
       return
     }
@@ -244,18 +247,19 @@ function HolidaysTab() {
         name: newName.trim() || undefined,
       })
       toast({
-        title: "\u0110\u00e3 th\u00eam ng\u00e0y ngh\u1ec9",
-        description: formatDisplayDate(isoDate) + " \u0111\u00e3 \u0111\u01b0\u1ee3c l\u01b0u.",
+        title: "Đã thêm ngày nghỉ",
+        description: formatDisplayDate(isoDate) + " đã được lưu.",
       })
       setNewDate(undefined)
       setNewName("")
       await load(year)
+      setLastImportDelta(null)
     } catch (error: unknown) {
       const message =
-        error instanceof Error ? error.message : "Kh\u00f4ng th\u1ec3 th\u00eam ng\u00e0y ngh\u1ec9"
+        error instanceof Error ? error.message : "Không thể thêm ngày nghỉ"
       toast({
         variant: "destructive",
-        title: "Th\u00eam th\u1ea5t b\u1ea1i",
+        title: "Thêm thất bại",
         description: message,
       })
     } finally {
@@ -268,18 +272,19 @@ function HolidaysTab() {
       try {
         await deleteHolidayEntry(holiday.id)
         toast({
-          title: "\u0110\u00e3 x\u00f3a ng\u00e0y ngh\u1ec9",
-          description: formatDisplayDate(holiday.day) + " \u0111\u00e3 \u0111\u01b0\u1ee3c g\u1ee1 b\u1ecf.",
+          title: "Đã xóa ngày nghỉ",
+          description: formatDisplayDate(holiday.day) + " đã được gỡ bỏ.",
         })
         await load(year)
+        setLastImportDelta(null)
       } catch (error: unknown) {
         const message =
           error instanceof Error
             ? error.message
-            : "Kh\u00f4ng th\u1ec3 x\u00f3a ng\u00e0y ngh\u1ec9"
+            : "Không thể xóa ngày nghỉ"
         toast({
           variant: "destructive",
-          title: "X\u00f3a th\u1ea5t b\u1ea1i",
+          title: "Xóa thất bại",
           description: message,
         })
       }
@@ -293,11 +298,11 @@ function HolidaysTab() {
         <div className="flex flex-wrap items-end gap-4">
           <div className="flex flex-col gap-1">
             <Label className="text-xs uppercase text-muted-foreground">
-              N\u0103m \u00e1p d\u1ee5ng
+              Năm áp dụng
             </Label>
             <Select value={String(year)} onValueChange={(value) => setYear(Number(value))}>
               <SelectTrigger className="h-10 w-32">
-                <SelectValue placeholder="Ch\u1ecdn n\u0103m" />
+                <SelectValue placeholder="Chọn năm" />
               </SelectTrigger>
               <SelectContent>
                 {yearOptions.map((option) => (
@@ -310,12 +315,32 @@ function HolidaysTab() {
           </div>
           <GlassButton
             variant="outline"
-            onClick={() => void load(year)}
+            onClick={() => {
+              setLastImportDelta(null)
+              void load(year)
+            }}
             disabled={loading}
             className="gap-2"
           >
-            <RefreshCcw className="h-4 w-4" /> T\u1ea3i l\u1ea1i
+            <RefreshCcw className="h-4 w-4" /> Tải lại
           </GlassButton>
+        </div>
+        <div
+          className="flex items-center gap-2 text-sm text-muted-foreground"
+          data-testid="holiday-count"
+        >
+          <span>Tổng số ngày nghỉ:</span>
+          <span className="font-medium text-slate-900 dark:text-slate-100">
+            {sortedHolidays.length}
+          </span>
+          {lastImportDelta && lastImportDelta > 0 ? (
+            <span
+              data-testid="holiday-count-diff"
+              className="font-medium text-emerald-600"
+            >
+              (+{lastImportDelta})
+            </span>
+          ) : null}
         </div>
         <GlassButton
           variant="primary"
@@ -324,7 +349,7 @@ function HolidaysTab() {
           className="gap-2"
         >
           <UploadCloud className="h-4 w-4" />
-          {importing ? "\u0110ang import\u2026" : "Import from Nager"}
+          {importing ? "Đang import…" : "Import from Nager"}
         </GlassButton>
       </div>
 
@@ -332,25 +357,25 @@ function HolidaysTab() {
         <div className="flex flex-wrap items-center gap-3">
           <CalendarPlus className="h-5 w-5 text-sky-500" aria-hidden="true" />
           <p className="text-sm text-muted-foreground">
-            Th\u00eam th\u1ee7 c\u00f4ng c\u00e1c ng\u00e0y ngh\u1ec9 \u0111\u1eb7c bi\u1ec7t trong n\u0103m.
+            Thêm thủ công các ngày nghỉ đặc biệt trong năm.
           </p>
         </div>
         <div className="flex flex-wrap items-end gap-4">
           <div className="flex flex-col gap-2">
             <Label className="text-xs uppercase text-muted-foreground">
-              Ng\u00e0y ngh\u1ec9
+              Ngày nghỉ
             </Label>
             <DatePicker value={newDate} onChange={setNewDate} />
           </div>
           <div className="flex flex-col gap-2">
             <Label htmlFor="holiday-name" className="text-xs uppercase text-muted-foreground">
-              Ghi ch\u00fa
+              Ghi chú
             </Label>
             <Input
               id="holiday-name"
               value={newName}
               onChange={(event) => setNewName(event.target.value)}
-              placeholder="T\u00ean ng\u00e0y ngh\u1ec9"
+              placeholder="Tên ngày nghỉ"
               className="w-[240px]"
             />
           </div>
@@ -361,7 +386,7 @@ function HolidaysTab() {
             className="gap-2"
           >
             <CalendarRange className="h-4 w-4" />
-            {adding ? "\u0110ang th\u00eam\u2026" : "Th\u00eam ng\u00e0y ngh\u1ec9"}
+            {adding ? "Đang thêm…" : "Thêm ngày nghỉ"}
           </GlassButton>
         </div>
       </div>
@@ -370,29 +395,29 @@ function HolidaysTab() {
         <Table stickyHeader>
           <TableHeader>
             <TableRow>
-              <TableHead className="w-[160px]">Ng\u00e0y</TableHead>
-              <TableHead>M\u00f4 t\u1ea3</TableHead>
-              <TableHead className="w-[140px] text-center">H\u00e0nh \u0111\u1ed9ng</TableHead>
+              <TableHead className="w-[160px]">Ngày</TableHead>
+              <TableHead>Mô tả</TableHead>
+              <TableHead className="w-[140px] text-center">Hành động</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {loading ? (
               <TableRow>
                 <TableCell colSpan={3} className="text-center text-muted-foreground">
-                  \u0110ang t\u1ea3i danh s\u00e1ch\u2026
+                  Đang tải danh sách…
                 </TableCell>
               </TableRow>
             ) : sortedHolidays.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={3} className="text-center text-muted-foreground">
-                  Ch\u01b0a c\u00f3 ng\u00e0y ngh\u1ec9 cho n\u0103m {year}.
+                  Chưa có ngày nghỉ cho năm {year}.
                 </TableCell>
               </TableRow>
             ) : (
               sortedHolidays.map((holiday) => (
                 <TableRow key={holiday.id ?? holiday.day}>
                   <TableCell>{formatDisplayDate(holiday.day)}</TableCell>
-                  <TableCell>{holiday.name ?? "\u2014"}</TableCell>
+                  <TableCell>{holiday.name ?? "—"}</TableCell>
                   <TableCell>
                     <div className="flex justify-center">
                       <GlassButton
@@ -401,7 +426,7 @@ function HolidaysTab() {
                         onClick={() => void handleRemove(holiday)}
                         className="gap-2"
                       >
-                        <Trash2 className="h-4 w-4" /> X\u00f3a
+                        <Trash2 className="h-4 w-4" /> Xóa
                       </GlassButton>
                     </div>
                   </TableCell>
@@ -429,8 +454,6 @@ function MonthPlanTab() {
   })
   const year = form.watch("year")
   const month = form.watch("month")
-  const [loading, setLoading] = React.useState(false)
-  const [saving, setSaving] = React.useState(false)
   const [generating, setGenerating] = React.useState(false)
   const [autoWorkingDays, setAutoWorkingDays] = React.useState<number | null>(null)
   const [weekendPolicy, setWeekendPolicy] = React.useState<WeekendPolicy>("sat_sun")
@@ -445,6 +468,34 @@ function MonthPlanTab() {
   )
   const [newOffday, setNewOffday] = React.useState<Date | undefined>()
   const [newWorkday, setNewWorkday] = React.useState<Date | undefined>()
+  const [generateErrorBanner, setGenerateErrorBanner] = React.useState<string | null>(null)
+
+  const numericYear =
+    typeof year === "number" && Number.isFinite(year) ? year : null
+  const numericMonth =
+    typeof month === "number" && Number.isFinite(month) ? month : null
+
+  const {
+    data: monthConfigData,
+    loading: monthConfigLoading,
+    saving: monthConfigSaving,
+    error: monthConfigError,
+    refetch: refetchMonthConfig,
+    save: saveMonthConfig,
+    isMissing: monthConfigMissing,
+  } = useMonthConfig(numericYear, numericMonth)
+
+  const {
+    data: shiftDefaultData,
+    loading: shiftDefaultsLoading,
+    saving: shiftDefaultsSaving,
+    error: shiftDefaultsError,
+    refetch: refetchShiftDefaults,
+    save: saveShiftDefaults,
+  } = useShiftDefaults(numericYear, numericMonth)
+
+  const loading = monthConfigLoading || shiftDefaultsLoading
+  const saving = monthConfigSaving || shiftDefaultsSaving
 
   const yearOptions = React.useMemo(() => {
     const fallbackYear = today.getFullYear()
@@ -454,60 +505,66 @@ function MonthPlanTab() {
     return Array.from({ length: 4 }, (_, index) => start + index)
   }, [today, year])
 
-  const load = React.useCallback(
-    async (targetYear: number, targetMonth: number) => {
-      setLoading(true)
-      try {
-        const [config, defaults] = await Promise.all([
-          getMonthConfig(targetYear, targetMonth),
-          getShiftDefaultConfig(targetYear, targetMonth),
-        ])
-
-        setWeekendPolicy(config.weekend_policy ?? "sat_sun")
-        setExtraOffdays(config.extra_offdays ?? [])
-        setExtraWorkdays(config.extra_workdays ?? [])
-        setAutoWorkingDays(
-          typeof config.auto_working_days === "number"
-            ? config.auto_working_days
-            : null,
-        )
-        setOverrideValue(
-          config.working_days_override === null ||
-            config.working_days_override === undefined
-            ? ""
-            : String(config.working_days_override),
-        )
-
-        const defaultsValue = { ...SHIFT_DEFAULT_BASE, ...(defaults?.defaults ?? {}) }
-        setShiftDefaults(defaultsValue)
-        setShiftFields(createShiftFields(defaultsValue))
-      } catch (error: unknown) {
-        const message =
-          error instanceof Error ? error.message : "Không thể tải cấu hình tháng"
-        toast({
-          variant: "destructive",
-          title: "Lỗi tải cấu hình",
-          description: message,
-        })
-      } finally {
-        setLoading(false)
-      }
-    },
-    [toast],
-  )
-
   React.useEffect(() => {
-    if (
-      typeof year !== "number" ||
-      !Number.isFinite(year) ||
-      typeof month !== "number" ||
-      !Number.isFinite(month)
-    ) {
+    if (!monthConfigData) {
+      setWeekendPolicy("sat_sun")
+      setExtraOffdays([])
+      setExtraWorkdays([])
+      setAutoWorkingDays(null)
+      setOverrideValue("")
       return
     }
 
-    void load(year, month)
-  }, [load, month, year])
+    setWeekendPolicy(monthConfigData.weekend_policy ?? "sat_sun")
+    setExtraOffdays(monthConfigData.extra_offdays ?? [])
+    setExtraWorkdays(monthConfigData.extra_workdays ?? [])
+    setAutoWorkingDays(
+      typeof monthConfigData.auto_working_days === "number"
+        ? monthConfigData.auto_working_days
+        : null,
+    )
+    setOverrideValue(
+      monthConfigData.working_days_override === null ||
+        monthConfigData.working_days_override === undefined
+        ? ""
+        : String(monthConfigData.working_days_override),
+    )
+  }, [monthConfigData])
+
+  React.useEffect(() => {
+    const defaultsValue = {
+      ...SHIFT_DEFAULT_BASE,
+      ...(shiftDefaultData?.defaults ?? {}),
+    }
+    setShiftDefaults(defaultsValue)
+    setShiftFields(createShiftFields(defaultsValue))
+  }, [shiftDefaultData])
+
+  React.useEffect(() => {
+    if (monthConfigError && !monthConfigData) {
+      toast({
+        variant: "destructive",
+        title: "Lỗi tải cấu hình",
+        description: monthConfigError,
+      })
+    }
+  }, [monthConfigData, monthConfigError, toast])
+
+  React.useEffect(() => {
+    if (shiftDefaultsError && !shiftDefaultData) {
+      toast({
+        variant: "destructive",
+        title: "Lỗi tải mặc định ca",
+        description: shiftDefaultsError,
+      })
+    }
+  }, [shiftDefaultData, shiftDefaultsError, toast])
+
+  React.useEffect(() => {
+    if (!monthConfigMissing) {
+      setGenerateErrorBanner(null)
+    }
+  }, [monthConfigMissing])
 
   const weekendOptions = React.useMemo(() => {
     if (!weekendPolicy) {
@@ -570,8 +627,11 @@ function MonthPlanTab() {
 
   const saveMonthPlan = React.useCallback(
     async (values: MonthPlanFormValues) => {
-      setSaving(true)
       try {
+        if (numericYear === null || numericMonth === null) {
+          throw new Error("Vui lòng chọn năm và tháng hợp lệ")
+        }
+
         const normalizedOverride = overrideValue.trim()
         const overrideNumber =
           normalizedOverride === "" ? null : Number(normalizedOverride)
@@ -579,34 +639,15 @@ function MonthPlanTab() {
           throw new Error("Giá trị override phải là số hợp lệ")
         }
 
-        const monthPayload: MonthConfig = await updateMonthConfig({
-          year: values.year,
-          month: values.month,
+        await saveMonthConfig({
           weekend_policy: weekendPolicy || "sat_sun",
-          auto_working_days: autoWorkingDays,
           extra_offdays: [...extraOffdays].sort(),
           extra_workdays: [...extraWorkdays].sort(),
           working_days_override: overrideNumber,
+          auto_working_days: autoWorkingDays,
         })
 
-        const defaultsPayload: ShiftDefaultConfig = await updateShiftDefaultConfig({
-          year: values.year,
-          month: values.month,
-          defaults: shiftDefaults,
-        })
-
-        setAutoWorkingDays(
-          typeof monthPayload.auto_working_days === "number"
-            ? monthPayload.auto_working_days
-            : autoWorkingDays,
-        )
-
-        const normalizedDefaults = {
-          ...SHIFT_DEFAULT_BASE,
-          ...(defaultsPayload?.defaults ?? {}),
-        }
-        setShiftDefaults(normalizedDefaults)
-        setShiftFields(createShiftFields(normalizedDefaults))
+        await saveShiftDefaults(shiftDefaults)
 
         toast({
           title: "Đã lưu cấu hình",
@@ -620,15 +661,17 @@ function MonthPlanTab() {
           title: "Lưu thất bại",
           description: message,
         })
-      } finally {
-        setSaving(false)
       }
     },
     [
       autoWorkingDays,
       extraOffdays,
       extraWorkdays,
+      numericMonth,
+      numericYear,
       overrideValue,
+      saveMonthConfig,
+      saveShiftDefaults,
       shiftDefaults,
       toast,
       weekendPolicy,
@@ -637,7 +680,16 @@ function MonthPlanTab() {
 
   const generateMonthPlan = React.useCallback(
     async (values: MonthPlanFormValues) => {
+      if (monthConfigMissing) {
+        const monthLabel = `${String(values.month).padStart(2, "0")}/${values.year}`
+        setGenerateErrorBanner(
+          `Tháng ${monthLabel} chưa được cấu hình. Vui lòng lưu thiết lập trước khi sinh lịch.`,
+        )
+        return
+      }
+
       setGenerating(true)
+      setGenerateErrorBanner(null)
       try {
         const result = await generateSchedule({
           year: values.year,
@@ -668,6 +720,8 @@ function MonthPlanTab() {
           title: "Đã gửi yêu cầu sinh lịch",
           description: detailMessage,
         })
+
+        await Promise.all([refetchMonthConfig(), refetchShiftDefaults()])
       } catch (error: unknown) {
         const message =
           error instanceof Error ? error.message : "Không thể sinh lịch"
@@ -680,7 +734,7 @@ function MonthPlanTab() {
         setGenerating(false)
       }
     },
-    [toast],
+    [monthConfigMissing, refetchMonthConfig, refetchShiftDefaults, toast],
   )
 
   const submitSave = React.useMemo(
@@ -774,6 +828,13 @@ function MonthPlanTab() {
             )}
           />
         </div>
+
+        {generateErrorBanner ? (
+          <Alert variant="destructive">
+            <AlertTitle>Thiếu cấu hình tháng</AlertTitle>
+            <AlertDescription>{generateErrorBanner}</AlertDescription>
+          </Alert>
+        ) : null}
 
         <div className="flex flex-wrap items-center gap-3 rounded-xl border border-slate-200/70 bg-white/70 px-4 py-3 dark:border-slate-800/70 dark:bg-slate-900/70">
           <Badge variant="primary" className="gap-2">

--- a/test/ConfigPage.test.tsx
+++ b/test/ConfigPage.test.tsx
@@ -42,7 +42,10 @@ describe("ConfigPage", () => {
     },
   }
 
-  const defaultHolidays: any[] = []
+  let monthConfigResponse: typeof defaultMonthConfig | null
+  let shiftDefaultsResponse: typeof defaultShiftDefaults | null
+  let holidayResponse: any[]
+  let nextImportedHolidays: any[]
 
   let fetchMock: ReturnType<typeof vi.fn>
   let savedMonthConfigBody: any
@@ -71,33 +74,52 @@ describe("ConfigPage", () => {
     savedMonthConfigBody = null
     savedShiftDefaultsBody = null
     savedGenerateBody = null
+    monthConfigResponse = { ...defaultMonthConfig }
+    shiftDefaultsResponse = { ...defaultShiftDefaults }
+    holidayResponse = []
+    nextImportedHolidays = []
 
     fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.url
       const method = (init?.method || (typeof input !== "string" ? input.method : undefined) || "GET").toUpperCase()
 
       if (url.startsWith("/api/holidays") && method === "GET") {
-        return jsonResponse(defaultHolidays)
+        return jsonResponse(holidayResponse)
+      }
+
+      if (url === "/api/holidays/import-nager" && method === "POST") {
+        const imported = nextImportedHolidays.length
+        holidayResponse = [...holidayResponse, ...nextImportedHolidays]
+        nextImportedHolidays = []
+        return jsonResponse({ imported })
       }
 
       if (url.startsWith("/api/month-config") && method === "GET") {
-        return jsonResponse(defaultMonthConfig)
+        if (!monthConfigResponse) {
+          return new Response("", { status: 404 })
+        }
+        return jsonResponse(monthConfigResponse)
       }
 
       if (url.startsWith("/api/shift-defaults") && method === "GET") {
-        return jsonResponse(defaultShiftDefaults)
+        if (!shiftDefaultsResponse) {
+          return new Response("", { status: 404 })
+        }
+        return jsonResponse(shiftDefaultsResponse)
       }
 
       if (url === "/api/month-config" && method === "PUT") {
         const body = JSON.parse(init?.body as string)
         savedMonthConfigBody = body
-        return jsonResponse({ ...defaultMonthConfig, ...body })
+        monthConfigResponse = { ...defaultMonthConfig, ...body }
+        return jsonResponse(monthConfigResponse)
       }
 
       if (url === "/api/shift-defaults" && method === "PUT") {
         const body = JSON.parse(init?.body as string)
         savedShiftDefaultsBody = body
-        return jsonResponse({ ...defaultShiftDefaults, defaults: body.defaults })
+        shiftDefaultsResponse = { ...defaultShiftDefaults, defaults: body.defaults }
+        return jsonResponse(shiftDefaultsResponse)
       }
 
       if (url === "/api/schedule/generate" && method === "POST") {
@@ -172,6 +194,29 @@ describe("ConfigPage", () => {
     })
   })
 
+  it("shows increased holiday count after importing", async () => {
+    holidayResponse = [
+      { id: 1, day: `${currentYear}-01-01`, name: "New Year" },
+    ]
+    nextImportedHolidays = [
+      { id: 2, day: `${currentYear}-04-30`, name: "Holiday 1" },
+      { id: 3, day: `${currentYear}-05-01`, name: "Holiday 2" },
+    ]
+
+    renderConfig()
+
+    const user = userEvent.setup()
+    const importButton = await screen.findByRole("button", { name: /Import from Nager/i })
+    expect(screen.getByTestId("holiday-count")).toHaveTextContent("1")
+
+    await user.click(importButton)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("holiday-count-diff")).toHaveTextContent("(+2)")
+    })
+    expect(screen.getByTestId("holiday-count")).toHaveTextContent("3")
+  })
+
   it("sends schedule generation request with current selection", async () => {
     renderConfig()
 
@@ -192,5 +237,24 @@ describe("ConfigPage", () => {
       month: currentMonth,
       fill_hc: false,
     })
+  })
+
+  it("shows banner when generating without existing month config", async () => {
+    monthConfigResponse = null
+
+    renderConfig()
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole("tab", { name: /Month plan/i }))
+
+    const generateButton = await screen.findByRole("button", { name: /Generate Schedule/i })
+    await waitFor(() => expect(generateButton).not.toBeDisabled())
+
+    await user.click(generateButton)
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("Thiếu cấu hình tháng")
+    expect(alert).toHaveTextContent("Vui lòng lưu thiết lập trước khi sinh lịch")
+    expect(savedGenerateBody).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- add hooks for month configuration and shift defaults with optimistic updates and 404 awareness
- update the Config page to surface holiday import deltas, reuse the hooks, and guard generation when no plan exists
- extend the ConfigPage tests for the save flow, holiday import feedback, and missing configuration banner

## Testing
- npm run test -- ConfigPage

------
https://chatgpt.com/codex/tasks/task_e_68de95a654b48320ab507d850f55396a