### PR TITLE
feat: add analytics dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - **Layout & routing**: `src/App.tsx` mounts the Apple-inspired sidebar shell (`AppleSidebar.tsx`) and lazy-loads pages (`Dashboard`, `Schedule`, `Chatbot*`, `DepartmentManagement`, `ShiftConfig`). Routes defined in `src/app/routes.tsx`. Keep skip-links and focus management intact.
 - **UI system**: Glassmorphism primitives (`GlassCard`, `GlassButton`, `GlassBadge`, `GlassPanel`) live in `src/components/ui/glass.tsx`. Always use these instead of raw components for consistent styling. Tailwind tokens in `src/index.css` under glass utility layer.
 - **Domain widgets**: Schedule matrix, fixed/off panels, toolbar, and legend are under `src/components/Schedule/`. Dashboard cards under `src/components/section-cards.tsx`. **New**: Department & shift management pages under `src/pages/DepartmentManagement.tsx` and `src/pages/ShiftConfig.tsx`.
+- **Analytics hub**: `src/pages/Analytics.tsx` renders staff workload, department comparison, attendance, and cost widgets backed by hooks in `src/hooks/useAnalyticsMetrics.ts`. Metrics hooks normalize API responses via `src/types/analytics.ts` and expose loading/error/empty states for reuse.
 
 ## Phase 1 & 2: Multi-Department Support (COMPLETED)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const ChatbotChunkingPage = lazy(() => import("./pages/ChatbotChunking"))
 const ConfigPage = lazy(() => import("./pages/Config"))
 const DepartmentManagementPage = lazy(() => import("./pages/DepartmentManagement"))
 const ShiftConfigPage = lazy(() => import("./pages/ShiftConfig"))
+const AnalyticsPage = lazy(() => import("./pages/Analytics"))
 
 const MAIN_CONTENT_ID = "app-main-content"
 
@@ -345,6 +346,7 @@ export default function App() {
             <div className="mx-auto flex w-full max-w-[1400px] flex-1 flex-col gap-6 px-6 py-6">
               <Routes>
                 <Route path="/" element={<DashboardPage />} />
+                <Route path="/analytics" element={<AnalyticsPage />} />
                 <Route
                   path="/schedule"
                   element={

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,4 +1,16 @@
-import { CalendarIcon, LayoutDashboardIcon, BotIcon, Upload, Scissors, Settings2, TableIcon, Building2, Users, Clock } from "lucide-react"
+import {
+  CalendarIcon,
+  LayoutDashboardIcon,
+  BotIcon,
+  Upload,
+  Scissors,
+  Settings2,
+  TableIcon,
+  Building2,
+  Users,
+  Clock,
+  BarChart3,
+} from "lucide-react"
 import type { LucideIcon } from "lucide-react"
 
 export type AppRoute = {
@@ -15,6 +27,12 @@ export const appRoutes: AppRoute[] = [
     label: "Dashboard",
     description: "Hiển thị KPI và trạng thái tài liệu mẫu",
     icon: LayoutDashboardIcon,
+  },
+  {
+    path: "/analytics",
+    label: "Analytics",
+    description: "Trang tổng quan phân tích vận hành",
+    icon: BarChart3,
   },
   {
     path: "/schedule",

--- a/src/hooks/useAnalyticsMetrics.ts
+++ b/src/hooks/useAnalyticsMetrics.ts
@@ -1,0 +1,319 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import {
+  attendanceResponseSchema,
+  costResponseSchema,
+  departmentComparisonResponseSchema,
+  type AttendanceSummary,
+  type CostSummary,
+  type DepartmentComparisonItem,
+  type StaffWorkloadItem,
+  staffWorkloadResponseSchema,
+} from "@/types/analytics"
+import { fetchJson } from "@/lib/api"
+
+interface AsyncState<T> {
+  data: T | null
+  loading: boolean
+  error: string | null
+}
+
+interface AsyncResult<T> extends AsyncState<T> {
+  refetch: () => Promise<T | null>
+  isEmpty: boolean
+}
+
+function normalizeStaffWorkload(raw: unknown): StaffWorkloadItem[] {
+  const parsed = staffWorkloadResponseSchema.safeParse(raw)
+  if (!parsed.success) {
+    return []
+  }
+
+  return parsed.data.map((item, index) => {
+    const id =
+      item.staff_id ?? item.staffId ?? item.name ?? item.staff_name ?? index
+    const name = item.staff_name ?? item.name ?? `Nhân viên ${index + 1}`
+    const totalHours = Math.max(0, item.total_hours ?? item.hours ?? 0)
+    const overtimeHours = Math.max(
+      0,
+      item.overtime_hours ?? item.overtime ?? 0,
+    )
+    return {
+      id: String(id),
+      name,
+      totalHours,
+      overtimeHours,
+    }
+  })
+}
+
+function normalizeDepartmentComparison(raw: unknown): DepartmentComparisonItem[] {
+  const parsed = departmentComparisonResponseSchema.safeParse(raw)
+  if (!parsed.success) {
+    return []
+  }
+
+  return parsed.data.map((item, index) => {
+    const id =
+      item.department_id ?? item.departmentId ?? item.department ?? index
+    const department = item.department ?? item.name ?? `Phòng ban ${index + 1}`
+    const totalHours = Math.max(0, item.total_hours ?? item.hours ?? 0)
+    const overtimeHours = Math.max(
+      0,
+      item.overtime_hours ?? item.overtime ?? 0,
+    )
+    const regularHours = Math.max(
+      0,
+      item.regular_hours ?? totalHours - overtimeHours,
+    )
+
+    return {
+      id: String(id),
+      department,
+      totalHours,
+      overtimeHours,
+      regularHours,
+    }
+  })
+}
+
+function normalizeAttendance(raw: unknown): AttendanceSummary | null {
+  const parsed = attendanceResponseSchema.safeParse(raw)
+  if (!parsed.success) {
+    return null
+  }
+
+  const attendanceRate =
+    parsed.data.attendance_rate ?? parsed.data.attendanceRate ?? 0
+  const present = Math.max(0, parsed.data.present ?? parsed.data.attendance ?? 0)
+  const absent = Math.max(0, parsed.data.absent ?? 0)
+  const total = Math.max(parsed.data.total ?? present + absent, 0)
+  const absences = (parsed.data.absences ?? parsed.data.records ?? []).map(
+    (absence, index) => {
+      const id =
+        absence.staff_id ?? absence.staffId ?? absence.name ?? index
+      return {
+        id: String(id),
+        name: absence.staff_name ?? absence.name ?? "Không rõ",
+        date: absence.date ?? null,
+        reason: absence.reason ?? null,
+        department: absence.department ?? null,
+      }
+    },
+  )
+
+  return {
+    attendanceRate,
+    present,
+    absent,
+    total,
+    absences,
+  }
+}
+
+function normalizeCost(raw: unknown): CostSummary | null {
+  const parsed = costResponseSchema.safeParse(raw)
+  if (!parsed.success) {
+    return null
+  }
+
+  const amount =
+    parsed.data.total_cost ??
+    parsed.data.cost ??
+    parsed.data.amount ??
+    0
+  const normalizedAmount = Math.max(0, amount)
+  const previousAmount =
+    parsed.data.previous_total_cost ??
+    parsed.data.previous_cost ??
+    parsed.data.previous_amount ??
+    null
+  const deltaPercentage =
+    parsed.data.delta_percentage ?? parsed.data.delta_percent ?? null
+  const currency =
+    parsed.data.currency ?? parsed.data.currency_code ?? "VND"
+  const label = parsed.data.label ?? parsed.data.month_label ?? null
+  const updatedAt = parsed.data.updated_at ?? null
+
+  return {
+    amount: normalizedAmount,
+    previousAmount,
+    deltaPercentage,
+    currency,
+    label,
+    updatedAt,
+  }
+}
+
+type RequestFactory = (signal: AbortSignal) => Promise<unknown>
+
+function useAsyncData<T>(factory: RequestFactory | null): AsyncResult<T> {
+  const [state, setState] = useState<AsyncState<T>>({
+    data: null,
+    loading: !!factory,
+    error: null,
+  })
+  const abortRef = useRef<AbortController | null>(null)
+
+  const refetch = useCallback(async () => {
+    if (!factory) {
+      setState({ data: null, loading: false, error: null })
+      return null
+    }
+
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setState((current) => ({ ...current, loading: true, error: null }))
+
+    try {
+      const result = await factory(controller.signal)
+      if (controller.signal.aborted) {
+        return null
+      }
+      setState({ data: result as T, loading: false, error: null })
+      return result as T
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return null
+      }
+      const message =
+        error instanceof Error ? error.message : "Không thể tải dữ liệu"
+      setState({ data: null, loading: false, error: message })
+      return null
+    }
+  }, [factory])
+
+  useEffect(() => {
+    void refetch()
+    return () => {
+      abortRef.current?.abort()
+    }
+  }, [refetch])
+
+  const isEmpty = useMemo(() => {
+    if (!state.data) {
+      return true
+    }
+
+    if (Array.isArray(state.data)) {
+      return state.data.length === 0
+    }
+
+    if (typeof state.data === "object" && state.data !== null) {
+      if ("total" in (state.data as Record<string, unknown>)) {
+        const total = (state.data as { total?: number }).total
+        if (typeof total === "number") {
+          return total === 0
+        }
+      }
+    }
+
+    return false
+  }, [state.data])
+
+  return {
+    ...state,
+    refetch,
+    isEmpty,
+  }
+}
+
+function buildStaffWorkloadFactory(
+  year: number | null | undefined,
+  month: number | null | undefined,
+): RequestFactory | null {
+  if (!Number.isFinite(year ?? NaN) || !Number.isFinite(month ?? NaN)) {
+    return null
+  }
+
+  return async (signal: AbortSignal) => {
+    const data = await fetchJson<unknown>(
+      `/api/metrics/staff-workload?year=${year}&month=${month}`,
+      { signal },
+    )
+    return normalizeStaffWorkload(data) as unknown
+  }
+}
+
+function buildDepartmentComparisonFactory(
+  year: number | null | undefined,
+  month: number | null | undefined,
+): RequestFactory | null {
+  if (!Number.isFinite(year ?? NaN) || !Number.isFinite(month ?? NaN)) {
+    return null
+  }
+
+  return async (signal: AbortSignal) => {
+    const data = await fetchJson<unknown>(
+      `/api/metrics/department-comparison?year=${year}&month=${month}`,
+      { signal },
+    )
+    return normalizeDepartmentComparison(data) as unknown
+  }
+}
+
+function buildAttendanceFactory(
+  from: string | null | undefined,
+  to: string | null | undefined,
+): RequestFactory | null {
+  if (!from || !to) {
+    return null
+  }
+
+  return async (signal: AbortSignal) => {
+    const params = new URLSearchParams({ from, to })
+    const data = await fetchJson<unknown>(
+      `/api/metrics/attendance?${params.toString()}`,
+      { signal },
+    )
+    return normalizeAttendance(data) as unknown
+  }
+}
+
+function buildCostFactory(
+  year: number | null | undefined,
+  month: number | null | undefined,
+): RequestFactory | null {
+  if (!Number.isFinite(year ?? NaN) || !Number.isFinite(month ?? NaN)) {
+    return null
+  }
+
+  return async (signal: AbortSignal) => {
+    const data = await fetchJson<unknown>(
+      `/api/metrics/cost?year=${year}&month=${month}`,
+      { signal },
+    )
+    return normalizeCost(data) as unknown
+  }
+}
+
+export function useStaffWorkload(year: number | null, month: number | null) {
+  const factory = useMemo(
+    () => buildStaffWorkloadFactory(year, month),
+    [month, year],
+  )
+  return useAsyncData<StaffWorkloadItem[]>(factory)
+}
+
+export function useDepartmentCompare(
+  year: number | null,
+  month: number | null,
+) {
+  const factory = useMemo(
+    () => buildDepartmentComparisonFactory(year, month),
+    [month, year],
+  )
+  return useAsyncData<DepartmentComparisonItem[]>(factory)
+}
+
+export function useAttendance(from: string | null, to: string | null) {
+  const factory = useMemo(() => buildAttendanceFactory(from, to), [from, to])
+  return useAsyncData<AttendanceSummary | null>(factory)
+}
+
+export function useCost(year: number | null, month: number | null) {
+  const factory = useMemo(() => buildCostFactory(year, month), [month, year])
+  return useAsyncData<CostSummary | null>(factory)
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -46,6 +46,13 @@ async function parseJsonResponse<T>(res: Response): Promise<T> {
   }
 }
 
+export async function fetchJson<T>(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<T> {
+  return parseJsonResponse<T>(await fetch(input, init))
+}
+
 export type ValidationConflict = {
   type?: string
   detail?: unknown

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,0 +1,551 @@
+import { useMemo, useState } from "react"
+import { Bar, BarChart, CartesianGrid, Cell, Legend, Pie, PieChart, XAxis, YAxis } from "recharts"
+import { Activity, TrendingDown, TrendingUp } from "lucide-react"
+
+import { PageHeader } from "@/components/PageHeader"
+import { GlassCard, GlassPanel } from "@/components/ui/glass"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useAttendance, useCost, useDepartmentCompare, useStaffWorkload } from "@/hooks/useAnalyticsMetrics"
+import { cn } from "@/lib/utils"
+
+const workloadChartConfig = {
+  totalHours: {
+    label: "Giờ làm việc",
+    color: "hsl(var(--chart-1))",
+  },
+  overtimeHours: {
+    label: "Tăng ca",
+    color: "hsl(var(--chart-2))",
+  },
+}
+
+const departmentChartConfig = {
+  regularHours: {
+    label: "Giờ tiêu chuẩn",
+    color: "hsl(var(--chart-3))",
+  },
+  overtimeHours: {
+    label: "Tăng ca",
+    color: "hsl(var(--chart-4))",
+  },
+}
+
+const attendanceChartConfig = {
+  present: {
+    label: "Hiện diện",
+    color: "hsl(var(--chart-1))",
+  },
+  absent: {
+    label: "Vắng mặt",
+    color: "hsl(var(--chart-2))",
+  },
+}
+
+const RANGE_OPTIONS = [
+  { value: "month", label: "Trong tháng", days: null },
+  { value: "30d", label: "30 ngày", days: 30 },
+  { value: "7d", label: "7 ngày", days: 7 },
+] as const
+
+type RangeValue = (typeof RANGE_OPTIONS)[number]["value"]
+
+type DateRange = {
+  from: string | null
+  to: string | null
+  display: string
+}
+
+function getDateRange(year: number, month: number, range: RangeValue): DateRange {
+  const monthStart = new Date(year, month - 1, 1)
+  const monthEnd = new Date(year, month, 0)
+  if (range === "month") {
+    const from = new Date(monthStart)
+    const to = new Date(monthEnd)
+    return {
+      from: from.toISOString().slice(0, 10),
+      to: to.toISOString().slice(0, 10),
+      display: `01/${String(month).padStart(2, "0")} - ${String(
+        to.getDate(),
+      ).padStart(2, "0")}/${String(month).padStart(2, "0")}`,
+    }
+  }
+
+  const days = RANGE_OPTIONS.find((option) => option.value === range)?.days ?? 7
+  const to = new Date(monthEnd)
+  const from = new Date(to)
+  from.setDate(from.getDate() - (days - 1))
+  return {
+    from: from.toISOString().slice(0, 10),
+    to: to.toISOString().slice(0, 10),
+    display: `${from.toLocaleDateString("vi-VN")} - ${to.toLocaleDateString("vi-VN")}`,
+  }
+}
+
+function formatCurrency(amount: number, currency: string) {
+  return new Intl.NumberFormat("vi-VN", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
+function normalizePercent(value: number | null | undefined): number {
+  if (!value || Number.isNaN(value)) {
+    return 0
+  }
+  if (value > 1) {
+    return Math.min(Math.max(value, 0), 100)
+  }
+  return Math.min(Math.max(value * 100, 0), 100)
+}
+
+export default function AnalyticsPage() {
+  const today = new Date()
+  const currentYear = today.getFullYear()
+  const [selectedYear, setSelectedYear] = useState(currentYear)
+  const [selectedMonth, setSelectedMonth] = useState(today.getMonth() + 1)
+  const [selectedRange, setSelectedRange] = useState<RangeValue>("month")
+
+  const workload = useStaffWorkload(selectedYear, selectedMonth)
+  const department = useDepartmentCompare(selectedYear, selectedMonth)
+  const attendanceRange = useMemo(
+    () => getDateRange(selectedYear, selectedMonth, selectedRange),
+    [selectedMonth, selectedRange, selectedYear],
+  )
+  const attendance = useAttendance(attendanceRange.from, attendanceRange.to)
+  const cost = useCost(selectedYear, selectedMonth)
+
+  const yearOptions = useMemo(() => {
+    return Array.from({ length: 5 }, (_, index) => currentYear - index)
+  }, [currentYear])
+
+  const attendancePercent = normalizePercent(attendance.data?.attendanceRate ?? null)
+  const costDelta = useMemo(() => {
+    if (!cost.data || cost.data.previousAmount === null) {
+      return null
+    }
+    if (cost.data.deltaPercentage !== null) {
+      return cost.data.deltaPercentage
+    }
+    if (cost.data.previousAmount === 0) {
+      return null
+    }
+    return ((cost.data.amount - cost.data.previousAmount) / cost.data.previousAmount) * 100
+  }, [cost.data])
+
+  const displayDelta = useMemo(() => {
+    if (costDelta === null) {
+      return null
+    }
+    const absolute = Math.abs(costDelta)
+    if (absolute === 0) {
+      return 0
+    }
+    return absolute <= 1 ? costDelta * 100 : costDelta
+  }, [costDelta])
+
+  return (
+    <div className="flex flex-col gap-6 pb-16">
+      <PageHeader
+        icon={Activity}
+        tagline="Operations Insights"
+        title="Analytics"
+        description="Theo dõi hiệu suất nhân viên, phòng ban và chi phí vận hành."
+      />
+
+      <GlassPanel variant="strong" className="flex flex-col gap-4 p-4">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="analytics-year">Năm</Label>
+            <Select
+              value={String(selectedYear)}
+              onValueChange={(value) => setSelectedYear(Number(value))}
+            >
+              <SelectTrigger id="analytics-year" className="w-32">
+                <SelectValue placeholder="Chọn năm" />
+              </SelectTrigger>
+              <SelectContent>
+                {yearOptions.map((year) => (
+                  <SelectItem key={year} value={String(year)}>
+                    {year}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="analytics-month">Tháng</Label>
+            <Select
+              value={String(selectedMonth)}
+              onValueChange={(value) => setSelectedMonth(Number(value))}
+            >
+              <SelectTrigger id="analytics-month" className="w-32">
+                <SelectValue placeholder="Chọn tháng" />
+              </SelectTrigger>
+              <SelectContent>
+                {Array.from({ length: 12 }, (_, index) => index + 1).map((month) => (
+                  <SelectItem key={month} value={String(month)}>
+                    {String(month).padStart(2, "0")}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="analytics-range">Khoảng thời gian</Label>
+            <Select
+              value={selectedRange}
+              onValueChange={(value: RangeValue) => setSelectedRange(value)}
+            >
+              <SelectTrigger id="analytics-range" className="w-40">
+                <SelectValue placeholder="Chọn khoảng" />
+              </SelectTrigger>
+              <SelectContent>
+                {RANGE_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <span className="ml-auto text-sm text-muted-foreground">
+            Dữ liệu điểm danh: {attendanceRange.display}
+          </span>
+        </div>
+      </GlassPanel>
+
+      <div className="@container/analytics grid gap-6 xl:grid-cols-3">
+        <GlassCard variant="strong" className="xl:col-span-2 p-6">
+          <header className="flex flex-col gap-1">
+            <h2 className="text-lg font-semibold text-foreground">Tải công việc nhân viên</h2>
+            <p className="text-sm text-muted-foreground">
+              Phân bổ giờ làm và tăng ca theo từng nhân viên trong tháng.
+            </p>
+          </header>
+          <div className="mt-6">
+            {workload.loading ? (
+              <WidgetSkeleton ariaLabel="Đang tải biểu đồ tải công việc" />
+            ) : workload.error ? (
+              <WidgetError message={workload.error} onRetry={workload.refetch} />
+            ) : workload.isEmpty ? (
+              <EmptyState message="Không có dữ liệu tải công việc." />
+            ) : (
+              <ChartContainer
+                config={workloadChartConfig}
+                className="h-[320px] aspect-auto"
+              >
+                <BarChart data={workload.data ?? []} margin={{ left: 12, right: 12, top: 12 }}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="name" tickLine={false} axisLine={false} tickMargin={10} minTickGap={16} />
+                  <YAxis tickLine={false} axisLine={false} tickMargin={8} />
+                  <ChartTooltip cursor={{ fill: "hsl(var(--muted))", opacity: 0.1 }} content={<ChartTooltipContent />} />
+                  <Legend />
+                  <Bar dataKey="totalHours" name="Giờ làm việc" fill="var(--color-totalHours)" radius={[8, 8, 0, 0]} />
+                  <Bar dataKey="overtimeHours" name="Tăng ca" fill="var(--color-overtimeHours)" radius={[8, 8, 0, 0]} />
+                </BarChart>
+              </ChartContainer>
+            )}
+          </div>
+        </GlassCard>
+
+        <GlassCard variant="strong" className="p-6">
+          <header className="flex items-start justify-between gap-2">
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Chi phí vận hành</h2>
+              <p className="text-sm text-muted-foreground">
+                Tổng chi phí cho tháng {String(selectedMonth).padStart(2, "0")}/{selectedYear}
+              </p>
+            </div>
+            <Activity className="size-5 text-sky-500" aria-hidden="true" />
+          </header>
+          <div className="mt-6 space-y-4">
+            {cost.loading ? (
+              <WidgetSkeleton ariaLabel="Đang tải dữ liệu chi phí" />
+            ) : cost.error ? (
+              <WidgetError message={cost.error} onRetry={cost.refetch} />
+            ) : cost.data ? (
+              <>
+                <div>
+                  <p className="text-sm text-muted-foreground">Tổng chi phí</p>
+                  <p className="text-3xl font-bold text-foreground">
+                    {formatCurrency(cost.data.amount, cost.data.currency)}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 text-sm">
+                  {displayDelta !== null && costDelta !== null ? (
+                    <span
+                      className={cn(
+                        "flex items-center gap-1 rounded-full px-2 py-1 font-medium",
+                        costDelta >= 0
+                          ? "bg-emerald-500/15 text-emerald-600"
+                          : "bg-rose-500/15 text-rose-600",
+                      )}
+                      aria-label={
+                        costDelta >= 0
+                          ? "Chi phí tăng so với tháng trước"
+                          : "Chi phí giảm so với tháng trước"
+                      }
+                    >
+                      {costDelta >= 0 ? (
+                        <TrendingUp className="size-4" aria-hidden="true" />
+                      ) : (
+                        <TrendingDown className="size-4" aria-hidden="true" />
+                      )}
+                      {Math.abs(displayDelta).toFixed(1)}%
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">
+                      Chưa có dữ liệu so sánh tháng trước
+                    </span>
+                  )}
+                  {cost.data.previousAmount !== null ? (
+                    <span className="text-muted-foreground">
+                      Tháng trước: {formatCurrency(cost.data.previousAmount, cost.data.currency)}
+                    </span>
+                  ) : null}
+                </div>
+                {cost.data.label ? (
+                  <p className="text-xs text-muted-foreground">
+                    Kỳ báo cáo: {cost.data.label}
+                  </p>
+                ) : null}
+                {cost.data.updatedAt ? (
+                  <p className="text-xs text-muted-foreground">
+                    Cập nhật: {new Date(cost.data.updatedAt).toLocaleString()}
+                  </p>
+                ) : null}
+              </>
+            ) : (
+              <EmptyState message="Không có dữ liệu chi phí." />
+            )}
+          </div>
+        </GlassCard>
+
+        <GlassCard variant="strong" className="xl:col-span-2 p-6">
+          <header className="flex flex-col gap-1">
+            <h2 className="text-lg font-semibold text-foreground">So sánh phòng ban</h2>
+            <p className="text-sm text-muted-foreground">
+              Tổng hợp giờ làm và tăng ca giữa các phòng ban.
+            </p>
+          </header>
+          <div className="mt-6">
+            {department.loading ? (
+              <WidgetSkeleton ariaLabel="Đang tải biểu đồ phòng ban" />
+            ) : department.error ? (
+              <WidgetError message={department.error} onRetry={department.refetch} />
+            ) : department.isEmpty ? (
+              <EmptyState message="Không có dữ liệu phòng ban." />
+            ) : (
+              <ChartContainer
+                config={departmentChartConfig}
+                className="h-[320px] aspect-auto"
+              >
+                <BarChart data={department.data ?? []} margin={{ left: 12, right: 12, top: 12 }}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="department" tickLine={false} axisLine={false} tickMargin={10} minTickGap={16} />
+                  <YAxis tickLine={false} axisLine={false} tickMargin={8} />
+                  <ChartTooltip content={<ChartTooltipContent formatter={(value) => `${Number(value).toFixed(1)} giờ`} />} />
+                  <Legend />
+                  <Bar
+                    dataKey="regularHours"
+                    name="Giờ tiêu chuẩn"
+                    stackId="hours"
+                    fill="var(--color-regularHours)"
+                    radius={[8, 8, 0, 0]}
+                  />
+                  <Bar
+                    dataKey="overtimeHours"
+                    name="Tăng ca"
+                    stackId="hours"
+                    fill="var(--color-overtimeHours)"
+                    radius={[8, 8, 0, 0]}
+                  />
+                </BarChart>
+              </ChartContainer>
+            )}
+          </div>
+        </GlassCard>
+
+        <GlassCard variant="strong" className="p-6">
+          <header className="flex flex-col gap-1">
+            <h2 className="text-lg font-semibold text-foreground">Điểm danh</h2>
+            <p className="text-sm text-muted-foreground">
+              Tỷ lệ hiện diện và danh sách nhân viên vắng mặt.
+            </p>
+          </header>
+          <div className="mt-6 grid gap-6 md:grid-cols-[minmax(0,_1fr)_minmax(0,_1.2fr)]">
+            {attendance.loading ? (
+              <WidgetSkeleton ariaLabel="Đang tải dữ liệu điểm danh" />
+            ) : attendance.error ? (
+              <WidgetError message={attendance.error} onRetry={attendance.refetch} />
+            ) : !attendance.data ? (
+              <EmptyState message="Không có dữ liệu điểm danh." />
+            ) : (
+              <>
+                <div className="flex flex-col items-center justify-center gap-4">
+                  <div className="relative flex h-40 w-40 items-center justify-center">
+                    <ChartContainer
+                      config={attendanceChartConfig}
+                      className="h-40 w-40 aspect-square"
+                    >
+                      <PieChart>
+                        <Pie
+                          dataKey="value"
+                          nameKey="name"
+                          data={[
+                            {
+                              name: "Hiện diện",
+                              value: attendance.data.present,
+                              fill: "var(--color-present)",
+                            },
+                            {
+                              name: "Vắng mặt",
+                              value: attendance.data.absent,
+                              fill: "var(--color-absent)",
+                            },
+                          ]}
+                          innerRadius={60}
+                          outerRadius={80}
+                          strokeWidth={2}
+                        >
+                          <Cell key="present" fill="var(--color-present)" />
+                          <Cell key="absent" fill="var(--color-absent)" />
+                        </Pie>
+                        <ChartTooltip
+                          content={
+                            <ChartTooltipContent
+                              formatter={(value, name) => `${name}: ${Number(value).toFixed(0)} người`}
+                            />
+                          }
+                        />
+                      </PieChart>
+                    </ChartContainer>
+                    <div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
+                      <span className="text-3xl font-semibold text-foreground">
+                        {attendancePercent.toFixed(1)}%
+                      </span>
+                      <span className="text-xs text-muted-foreground">Hiện diện</span>
+                    </div>
+                  </div>
+                  <div className="text-center text-sm text-muted-foreground">
+                    {attendance.data.present} / {attendance.data.total} nhân viên hiện diện
+                  </div>
+                </div>
+                <div className="flex flex-col gap-3">
+                  <h3 className="text-sm font-semibold text-foreground">Danh sách vắng mặt</h3>
+                  {attendance.data.absences.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      Không có ghi nhận vắng mặt trong giai đoạn này.
+                    </p>
+                  ) : (
+                    <ul className="space-y-3">
+                      {attendance.data.absences.slice(0, 6).map((absence) => (
+                        <li
+                          key={absence.id}
+                          className="flex flex-col rounded-lg border border-white/40 bg-white/70 p-3 text-sm shadow-sm backdrop-blur-xl dark:border-slate-800/60 dark:bg-slate-900/70"
+                        >
+                          <span className="font-medium text-foreground">{absence.name}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {absence.department ?? "Không rõ phòng ban"}
+                          </span>
+                          {absence.date ? (
+                            <span className="text-xs text-muted-foreground">
+                              Ngày: {new Date(absence.date).toLocaleDateString()}
+                            </span>
+                          ) : null}
+                          {absence.reason ? (
+                            <span className="text-xs text-muted-foreground">Lý do: {absence.reason}</span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                  {attendance.data.absences.length > 6 ? (
+                    <p className="text-xs text-muted-foreground">
+                      Hiển thị 6/ {attendance.data.absences.length} trường hợp vắng mặt.
+                    </p>
+                  ) : null}
+                </div>
+              </>
+            )}
+          </div>
+        </GlassCard>
+      </div>
+    </div>
+  )
+}
+
+type WidgetSkeletonProps = {
+  ariaLabel: string
+}
+
+function WidgetSkeleton({ ariaLabel }: WidgetSkeletonProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={ariaLabel}
+      className="flex h-[280px] flex-col justify-between"
+    >
+      <Skeleton className="h-8 w-full" />
+      <Skeleton className="h-8 w-full" />
+      <Skeleton className="h-8 w-full" />
+      <Skeleton className="h-8 w-full" />
+    </div>
+  )
+}
+
+type WidgetErrorProps = {
+  message: string
+  onRetry: () => Promise<unknown>
+}
+
+function WidgetError({ message, onRetry }: WidgetErrorProps) {
+  return (
+    <div
+      role="alert"
+      className="flex h-[280px] flex-col items-start justify-center gap-3 text-sm text-red-600"
+    >
+      <p className="font-semibold">Không thể tải dữ liệu</p>
+      <p className="text-muted-foreground">{message}</p>
+      <button
+        type="button"
+        onClick={() => {
+          void onRetry()
+        }}
+        className="rounded-md bg-gradient-to-r from-sky-500 to-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+      >
+        Thử lại
+      </button>
+    </div>
+  )
+}
+
+type EmptyStateProps = {
+  message: string
+}
+
+function EmptyState({ message }: EmptyStateProps) {
+  return (
+    <div className="flex h-[280px] flex-col items-center justify-center text-sm text-muted-foreground">
+      {message}
+    </div>
+  )
+}

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,0 +1,136 @@
+import { z } from "zod"
+
+export const staffWorkloadItemSchema = z.object({
+  staff_id: z.union([z.string(), z.number()]).optional(),
+  staffId: z.union([z.string(), z.number()]).optional(),
+  staff_name: z.string().optional(),
+  name: z.string().optional(),
+  total_hours: z.number().optional(),
+  hours: z.number().optional(),
+  overtime_hours: z.number().optional(),
+  overtime: z.number().optional(),
+  regular_hours: z.number().optional(),
+})
+
+export const staffWorkloadResponseSchema = z
+  .array(staffWorkloadItemSchema)
+  .or(z.object({ data: z.array(staffWorkloadItemSchema) }))
+  .or(z.object({ staff: z.array(staffWorkloadItemSchema) }))
+  .transform((value) => {
+    if (Array.isArray(value)) {
+      return value
+    }
+    if ("data" in value) {
+      return value.data
+    }
+    if ("staff" in value) {
+      return value.staff
+    }
+    return []
+  })
+
+export type StaffWorkloadItem = {
+  id: string
+  name: string
+  totalHours: number
+  overtimeHours: number
+}
+
+export const departmentComparisonItemSchema = z.object({
+  department_id: z.union([z.string(), z.number()]).optional(),
+  departmentId: z.union([z.string(), z.number()]).optional(),
+  department: z.string().optional(),
+  name: z.string().optional(),
+  total_hours: z.number().optional(),
+  hours: z.number().optional(),
+  overtime_hours: z.number().optional(),
+  overtime: z.number().optional(),
+  regular_hours: z.number().optional(),
+})
+
+export const departmentComparisonResponseSchema = z
+  .array(departmentComparisonItemSchema)
+  .or(z.object({ data: z.array(departmentComparisonItemSchema) }))
+  .or(z.object({ departments: z.array(departmentComparisonItemSchema) }))
+  .transform((value) => {
+    if (Array.isArray(value)) {
+      return value
+    }
+    if ("data" in value) {
+      return value.data
+    }
+    if ("departments" in value) {
+      return value.departments
+    }
+    return []
+  })
+
+export type DepartmentComparisonItem = {
+  id: string
+  department: string
+  totalHours: number
+  overtimeHours: number
+  regularHours: number
+}
+
+export const attendanceAbsenceSchema = z.object({
+  staff_id: z.union([z.string(), z.number()]).optional(),
+  staffId: z.union([z.string(), z.number()]).optional(),
+  staff_name: z.string().optional(),
+  name: z.string().optional(),
+  date: z.string().optional(),
+  reason: z.string().optional(),
+  department: z.string().optional(),
+})
+
+export const attendanceResponseSchema = z.object({
+  attendance_rate: z.number().optional(),
+  attendanceRate: z.number().optional(),
+  present: z.number().optional(),
+  attendance: z.number().optional(),
+  total: z.number().optional(),
+  absent: z.number().optional(),
+  absences: z.array(attendanceAbsenceSchema).optional(),
+  records: z.array(attendanceAbsenceSchema).optional(),
+})
+
+export type AttendanceSummary = {
+  attendanceRate: number
+  present: number
+  absent: number
+  total: number
+  absences: AttendanceAbsence[]
+}
+
+export type AttendanceAbsence = {
+  id: string
+  name: string
+  date: string | null
+  reason: string | null
+  department: string | null
+}
+
+export const costResponseSchema = z.object({
+  total_cost: z.number().optional(),
+  cost: z.number().optional(),
+  amount: z.number().optional(),
+  currency: z.string().optional(),
+  currency_code: z.string().optional(),
+  previous_total_cost: z.number().optional(),
+  previous_cost: z.number().optional(),
+  previous_amount: z.number().optional(),
+  delta_percentage: z.number().optional(),
+  delta_percent: z.number().optional(),
+  label: z.string().optional(),
+  month_label: z.string().optional(),
+  updated_at: z.string().optional(),
+})
+
+export type CostSummary = {
+  amount: number
+  previousAmount: number | null
+  deltaPercentage: number | null
+  currency: string
+  label: string | null
+  updatedAt: string | null
+}

--- a/test/useAnalyticsMetrics.test.tsx
+++ b/test/useAnalyticsMetrics.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useAttendance, useStaffWorkload } from "@/hooks/useAnalyticsMetrics"
+
+const originalFetch = global.fetch
+let fetchMock: ReturnType<typeof vi.fn>
+
+function createResponse(body: unknown, ok = true, statusText = "OK") {
+  return {
+    ok,
+    statusText,
+    text: vi.fn(async () => JSON.stringify(body)),
+  } as unknown as Response
+}
+
+describe("useAnalyticsMetrics hooks", () => {
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    global.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    fetchMock.mockReset()
+    global.fetch = originalFetch
+  })
+
+  it("loads staff workload data and normalizes response", async () => {
+    const mockData = [
+      { staff_id: 1, staff_name: "Alice", total_hours: 160, overtime_hours: 12 },
+      { staff_id: 2, staff_name: "Bob", total_hours: 150 },
+    ]
+    fetchMock.mockResolvedValue(createResponse(mockData))
+
+    const { result } = renderHook(() => useStaffWorkload(2024, 6))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/metrics/staff-workload?year=2024&month=6",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+    expect(result.current.error).toBeNull()
+    expect(result.current.data).toEqual([
+      { id: "1", name: "Alice", totalHours: 160, overtimeHours: 12 },
+      { id: "2", name: "Bob", totalHours: 150, overtimeHours: 0 },
+    ])
+    expect(result.current.isEmpty).toBe(false)
+  })
+
+  it("exposes errors when the workload request fails", async () => {
+    fetchMock.mockResolvedValue(
+      createResponse({ error: "Invalid selection" }, false, "Bad Request"),
+    )
+
+    const { result } = renderHook(() => useStaffWorkload(2024, 6))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.data).toBeNull()
+    expect(result.current.error).toBe("Invalid selection")
+  })
+
+  it("normalizes attendance payloads with optional fields", async () => {
+    const attendancePayload = {
+      attendance_rate: 0.92,
+      present: 46,
+      absent: 4,
+      absences: [
+        {
+          staff_id: 7,
+          staff_name: "Jane",
+          date: "2024-06-03",
+          reason: "Nghỉ phép",
+          department: "CSKH",
+        },
+      ],
+    }
+    fetchMock.mockResolvedValue(createResponse(attendancePayload))
+
+    const { result } = renderHook(() => useAttendance("2024-06-01", "2024-06-30"))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/metrics/attendance?from=2024-06-01&to=2024-06-30",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+    expect(result.current.error).toBeNull()
+    expect(result.current.data).toEqual({
+      attendanceRate: 0.92,
+      present: 46,
+      absent: 4,
+      total: 50,
+      absences: [
+        {
+          id: "7",
+          name: "Jane",
+          date: "2024-06-03",
+          reason: "Nghỉ phép",
+          department: "CSKH",
+        },
+      ],
+    })
+    expect(result.current.isEmpty).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- introduce analytics metrics hooks and types to normalize API responses
- add the /analytics route with workload, department, attendance, and cost widgets
- expose the new analytics navigation entry inside the sidebar and router config

## Testing
- npx vitest run test/useAnalyticsMetrics.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dfd6be0b648320aa33640393caab58